### PR TITLE
allow unstable acceptance tests to fail

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -15,6 +15,8 @@ Rakefile:
   litmus:
     provision_list:
       - ---travis_el
+  allow_failures:
+    - stage: acceptance
 Gemfile:
   optional:
     ':development':

--- a/.sync.yml
+++ b/.sync.yml
@@ -16,7 +16,8 @@ Rakefile:
     provision_list:
       - ---travis_el
   allow_failures:
-    - stage: acceptance
+    - env: PLATFORMS=travis_deb_puppet5
+    - env: PLATFORMS=travis_deb_puppet6
 Gemfile:
   optional:
     ':development':

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,9 @@ jobs:
       stage: deploy
   allow_failures:
     -
-      stage: acceptance
+      env: PLATFORMS=travis_deb_puppet5
+    -
+      env: PLATFORMS=travis_deb_puppet6
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,9 @@ jobs:
     -
       env: DEPLOY_TO_FORGE=yes
       stage: deploy
+  allow_failures:
+    -
+      stage: acceptance
 branches:
   only:
     - master


### PR DESCRIPTION
Acceptance checks rely on external service, which seems to be unstable now.