### PR TITLE
Fix warning() function name

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,7 +13,7 @@ class geoip::config {
       contain geoip::systemd::service
     }
     default: {
-      warn("unknown service provider (${srv}).")
+      warning("unknown service provider (${srv}).")
     } # default
   }
 }

--- a/spec/classes/30_config_spec.rb
+++ b/spec/classes/30_config_spec.rb
@@ -14,8 +14,24 @@ describe 'geoip' do
           end
 
           it { is_expected.to contain_class("geoip::config::#{config_for(os)[:class]}") }
+          it { is_expected.to contain_class('geoip::systemd::service') }
         end
       end
     end # on_supported_os.each
+
+    context 'on unsupported os' do
+      let(:facts) do
+        {
+          service_provider: 'foobar',
+        }
+      end
+      let(:params) do
+        default_config('unsupported-os')
+      end
+
+      it 'raise a warning' do
+        expect { catalogue }.to raise_error(Puppet::PreformattedError, %r{unknown service provider \(foobar\).})
+      end
+    end
   end
 end # describe 'geoip'


### PR DESCRIPTION
Puppet does not have a warn() function, causing a fatal error to happen
when a warning is to be issued.

https://puppet.com/docs/puppet/latest/function.html#warning