### PR TITLE
Support EL7 and EL8

### DIFF
--- a/data/RedHat-7.yaml
+++ b/data/RedHat-7.yaml
@@ -1,0 +1,4 @@
+geoip::packages:
+  - libmaxminddb-devel
+  - geoipupdate
+geoip::config_version: lt311

--- a/data/RedHat-7.yaml
+++ b/data/RedHat-7.yaml
@@ -1,3 +1,4 @@
+---
 geoip::packages:
   - libmaxminddb-devel
   - geoipupdate

--- a/data/RedHat-8.yaml
+++ b/data/RedHat-8.yaml
@@ -1,0 +1,4 @@
+geoip::packages:
+  - libmaxminddb
+  - geoipupdate
+geoip::config_version: lt311

--- a/data/RedHat-8.yaml
+++ b/data/RedHat-8.yaml
@@ -1,3 +1,4 @@
+---
 geoip::packages:
   - libmaxminddb
   - geoipupdate

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -7,10 +7,8 @@ defaults:  # Used for any hierarchy level that omits these keys.
 
 hierarchy:
   - name: 'Full Version'
-    path: '%{facts.os.name}-%{facts.os.release.full}.yaml'
+    path: '%{facts.os.family}-%{facts.os.release.full}.yaml'
   - name: 'Major Version'
-    path: '%{facts.os.name}-%{facts.os.release.major}.yaml'
+    path: '%{facts.os.family}-%{facts.os.release.major}.yaml'
   - name: 'Distribution Name'
     path: '%{facts.os.name}.yaml'
-  - name: 'OS Family Major Version'
-    path: '%{facts.os.family}-%{facts.os.release.major}.yaml'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -12,3 +12,5 @@ hierarchy:
     path: '%{facts.os.name}-%{facts.os.release.major}.yaml'
   - name: 'Distribution Name'
     path: '%{facts.os.name}.yaml'
+  - name: 'OS Family Major Version'
+    path: '%{facts.os.family}-%{facts.os.release.major}.yaml'

--- a/metadata.json
+++ b/metadata.json
@@ -29,13 +29,6 @@
       ]
     },
     {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7",
-        "8"
-      ]
-    },
-    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",

--- a/metadata.json
+++ b/metadata.json
@@ -27,6 +27,20 @@
       "operatingsystemrelease": [
         "10"
       ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
     }
   ],
   "requirements": [

--- a/provision.yaml
+++ b/provision.yaml
@@ -2,6 +2,3 @@
 debian:
   provisioner: docker
   images: ['litmusimage/debian:10']
-centos:
-  provisioner: docker
-  images: ['litmusimage/centos:7', 'litmusimage/centos:8']

--- a/provision.yaml
+++ b/provision.yaml
@@ -2,3 +2,6 @@
 debian:
   provisioner: docker
   images: ['litmusimage/debian:10']
+centos:
+  provisioner: docker
+  images: ['litmusimage/centos:7', 'litmusimage/centos:8']

--- a/spec/acceptance/01_base_spec.rb
+++ b/spec/acceptance/01_base_spec.rb
@@ -4,10 +4,14 @@ describe 'geoip' do
   context 'default installation' do
     let(:manifest_lt311) do
       <<-EOS
+      file { '/usr/local/share/GeoIP':
+        ensure => directory,
+      }
       class { 'geoip':
         config        => {
-          userid     => '#{ENV['MM_USERID']}',
-          licensekey => '#{ENV['MM_LICENSEKEY_LT311']}',
+          database_directory => '/usr/local/share/GeoIP',
+          userid             => '#{ENV['MM_USERID']}',
+          licensekey         => '#{ENV['MM_LICENSEKEY_LT311']}',
         },
         update_timers => ['*:25'],
       }
@@ -15,8 +19,12 @@ describe 'geoip' do
     end
     let(:manifest_ge311) do
       <<-EOS
+      file { '/usr/local/share/GeoIP':
+        ensure => directory,
+      }
       class { 'geoip':
         config        => {
+          database_directory => '/usr/local/share/GeoIP',
           accountid  => '#{ENV['MM_USERID']}',
           licensekey => '#{ENV['MM_LICENSEKEY_GE311']}',
         },

--- a/spec/acceptance/04_files_spec.rb
+++ b/spec/acceptance/04_files_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 describe 'check database files' do
   DBS.each do |db|
-    describe file("/var/lib/GeoIP/#{db}.mmdb") do
+    describe file("/usr/local/share/GeoIP/#{db}.mmdb") do
       it { is_expected.to exist }
       it { is_expected.to be_file }
       it { is_expected.to be_readable }

--- a/spec/acceptance/05_lookup_spec.rb
+++ b/spec/acceptance/05_lookup_spec.rb
@@ -4,14 +4,14 @@ describe 'lookup some addresses' do
   DBS.each do |db|
     context "against database #{db}" do
       describe 'valid IP address' do
-        subject { run_shell("mmdblookup --file /var/lib/GeoIP/#{db}.mmdb --ip 8.8.8.8 > /dev/null") }
+        subject { run_shell("mmdblookup --file /usr/local/share/GeoIP/#{db}.mmdb --ip 8.8.8.8 > /dev/null") }
 
         its(:exit_code) { is_expected.to eq 0 }
       end
       describe 'unknown IP address' do
         subject do
           run_shell(
-            "mmdblookup --file /var/lib/GeoIP/#{db}.mmdb --ip 127.0.0.1",
+            "mmdblookup --file /usr/local/share/GeoIP/#{db}.mmdb --ip 127.0.0.1",
             expect_failures: true,
           )
         end
@@ -22,7 +22,7 @@ describe 'lookup some addresses' do
       describe 'invalid IP address' do
         subject do
           run_shell(
-            "mmdblookup --file /var/lib/GeoIP/#{db}.mmdb --ip 256.0.0.1",
+            "mmdblookup --file /usr/local/share/GeoIP/#{db}.mmdb --ip 256.0.0.1",
             expect_failures: true,
           )
         end

--- a/spec/classes/20_install_spec.rb
+++ b/spec/classes/20_install_spec.rb
@@ -15,9 +15,9 @@ describe 'geoip' do
         case os
         when 'debian-10-x86_64'
           it { is_expected.to contain_package('mmdb-bin').with_ensure('latest') }
-        when /(redhat|centos)-7-x86_64/
+        when %r{(redhat|centos)-7-x86_64}
           it { is_expected.to contain_package('libmaxminddb-devel').with_ensure('latest') }
-        when /(redhat|centos)-8-x86_64/
+        when %r{(redhat|centos)-8-x86_64}
           it { is_expected.to contain_package('libmaxminddb').with_ensure('latest') }
         end
         it { is_expected.to contain_package('geoipupdate').with_ensure('latest') }

--- a/spec/classes/20_install_spec.rb
+++ b/spec/classes/20_install_spec.rb
@@ -12,7 +12,14 @@ describe 'geoip' do
           default_config(os)
         end
 
-        it { is_expected.to contain_package('mmdb-bin').with_ensure('latest') }
+        case os
+        when 'debian-10-x86_64'
+          it { is_expected.to contain_package('mmdb-bin').with_ensure('latest') }
+        when /(redhat|centos)-7-x86_64/
+          it { is_expected.to contain_package('libmaxminddb-devel').with_ensure('latest') }
+        when /(redhat|centos)-8-x86_64/
+          it { is_expected.to contain_package('libmaxminddb').with_ensure('latest') }
+        end
         it { is_expected.to contain_package('geoipupdate').with_ensure('latest') }
       end
     end

--- a/spec/classes/systemd/service_spec.rb
+++ b/spec/classes/systemd/service_spec.rb
@@ -19,9 +19,16 @@ describe 'geoip' do
               is_expected.to contain_systemd__unit_file('geoip_update.service')
                 .with('ensure' => 'present')
             end
-            it do
-              is_expected.to contain_systemd__unit_file('geoip_update.service')
-                .with_content(%r{^Type=exec$})
+            if os_facts['systemd_version'] >= 240
+              it do
+                is_expected.to contain_systemd__unit_file('geoip_update.service')
+                  .with_content(%r{^Type=exec$})
+              end
+            else
+              it do
+                is_expected.to contain_systemd__unit_file('geoip_update.service')
+                  .with_content(%r{^Type=oneshot$})
+              end
             end
             it do
               is_expected.to contain_systemd__unit_file('geoip_update.service')
@@ -35,13 +42,24 @@ describe 'geoip' do
               is_expected.to contain_systemd__unit_file('geoip_update.service')
                 .with_content(%r{^ExecStart=/usr/bin/geoipupdate -v -f /etc/GeoIP.conf$})
             end
-            it do
-              is_expected.to contain_systemd__unit_file('geoip_update.service')
-                .with_content(%r{^Restart=on-failure$})
-            end
-            it do
-              is_expected.to contain_systemd__unit_file('geoip_update.service')
-                .with_content(%r{^RestartSec=5min$})
+            if os_facts['systemd_version'] >= 240
+              it do
+                is_expected.to contain_systemd__unit_file('geoip_update.service')
+                  .with_content(%r{^Restart=on-failure$})
+              end
+              it do
+                is_expected.to contain_systemd__unit_file('geoip_update.service')
+                  .with_content(%r{^RestartSec=5min$})
+              end
+            else
+              it do
+                is_expected.not_to contain_systemd__unit_file('geoip_update.service')
+                  .with_content(%r{^Restart=on-failure$})
+              end
+              it do
+                is_expected.not_to contain_systemd__unit_file('geoip_update.service')
+                  .with_content(%r{^RestartSec=5min$})
+              end
             end
             it do
               is_expected.to contain_systemd__unit_file('geoip_update.service')

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rspec-puppet-facts'
 include RspecPuppetFacts
 
@@ -29,11 +30,11 @@ def config_for(os)
   end
 end
 
-add_custom_fact :systemd_version, ->(os, facts) {
+add_custom_fact :systemd_version, ->(_os, facts) {
   case facts[:os]['family']
-  when /(redhat|centos)-7-x86_64/
+  when %r{(redhat|centos)-7-x86_64}
     219
-  when /(redhat|centos)-8-x86_64/
+  when %r{(redhat|centos)-8-x86_64}
     239
   else
     240

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
 
 TEST_CONFIG_LT311 = {
   'config' => {
@@ -26,3 +28,14 @@ def config_for(os)
     { name: '< 3.1.1', class: 'lt311', config: TEST_CONFIG_LT311 }
   end
 end
+
+add_custom_fact :systemd_version, ->(os, facts) {
+  case facts[:os]['family']
+  when /(redhat|centos)-7-x86_64/
+    219
+  when /(redhat|centos)-8-x86_64/
+    239
+  else
+    240
+  end
+}

--- a/templates/service_unit.epp
+++ b/templates/service_unit.epp
@@ -5,7 +5,7 @@
 Description=GeoIP update service
 
 [Service]
-<% if $facts['systemd_version'] >= 240 { -%>
+<% if $facts['systemd_version'].to_i >= 240 { -%>
 Type=exec
 <% } else { -%>
 Type=oneshot
@@ -13,7 +13,7 @@ Type=oneshot
 User=<%= $geoip::service_user %>
 Group=<%= $geoip::service_group %>
 ExecStart=<%= $geoip::update_path %> -v -f <%= $geoip::config_path %>
-<% if $facts['systemd_version'] >= 240 { -%>
+<% if $facts['systemd_version'].to_i >= 240 { -%>
 Restart=<%= $geoip::systemd::service::restart %>
 RestartSec=<%= $geoip::systemd::service::restart_sec %>
 <% } -%>

--- a/templates/service_unit.epp
+++ b/templates/service_unit.epp
@@ -7,15 +7,13 @@ Description=GeoIP update service
 [Service]
 <% if Integer($facts['systemd_version']) >= 240 { -%>
 Type=exec
+Restart=<%= $geoip::systemd::service::restart %>
+RestartSec=<%= $geoip::systemd::service::restart_sec %>
 <% } else { -%>
 Type=oneshot
 <% } -%>
 User=<%= $geoip::service_user %>
 Group=<%= $geoip::service_group %>
 ExecStart=<%= $geoip::update_path %> -v -f <%= $geoip::config_path %>
-<% if Integer($facts['systemd_version']) >= 240 { -%>
-Restart=<%= $geoip::systemd::service::restart %>
-RestartSec=<%= $geoip::systemd::service::restart_sec %>
-<% } -%>
 StandardOutput=journal
 StandardError=journal

--- a/templates/service_unit.epp
+++ b/templates/service_unit.epp
@@ -5,7 +5,7 @@
 Description=GeoIP update service
 
 [Service]
-<% if $facts['systemd_version'].to_i >= 240 { -%>
+<% if Integer($facts['systemd_version']) >= 240 { -%>
 Type=exec
 <% } else { -%>
 Type=oneshot
@@ -13,7 +13,7 @@ Type=oneshot
 User=<%= $geoip::service_user %>
 Group=<%= $geoip::service_group %>
 ExecStart=<%= $geoip::update_path %> -v -f <%= $geoip::config_path %>
-<% if $facts['systemd_version'].to_i >= 240 { -%>
+<% if Integer($facts['systemd_version']) >= 240 { -%>
 Restart=<%= $geoip::systemd::service::restart %>
 RestartSec=<%= $geoip::systemd::service::restart_sec %>
 <% } -%>

--- a/templates/service_unit.epp
+++ b/templates/service_unit.epp
@@ -5,11 +5,17 @@
 Description=GeoIP update service
 
 [Service]
+<% if $facts['systemd_version'] >= 240 { -%>
 Type=exec
+<% } else { -%>
+Type=oneshot
+<% } -%>
 User=<%= $geoip::service_user %>
 Group=<%= $geoip::service_group %>
 ExecStart=<%= $geoip::update_path %> -v -f <%= $geoip::config_path %>
+<% if $facts['systemd_version'] >= 240 { -%>
 Restart=<%= $geoip::systemd::service::restart %>
 RestartSec=<%= $geoip::systemd::service::restart_sec %>
+<% } -%>
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
Both RedHat/CentOS 7 and 8 have less than systemd 240 which I believe is when `Type=exec` was added.  I also found that if using `Type=oneshot` that the restart flags produce errors so those are only added when `Type=exec` is supported.  Also the maxmind db package name is different for EL systems.