### PR TITLE
add config version to Debian-11 setup

### DIFF
--- a/data/Debian-11.yaml
+++ b/data/Debian-11.yaml
@@ -1,0 +1,2 @@
+---
+geoip::config_version: ge311

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -15,7 +15,7 @@ end
 def config_ge311?
   node_facts = facts_from_node(inventory_hash_from_inventory_file, ENV['TARGET_HOST']) || {}
   case node_facts['platform']
-  when %r{debian:10}, %r{ubuntu:20\.04}
+  when %r{debian:1[01]}, %r{ubuntu:20\.04}
     true
   else
     false

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -23,7 +23,7 @@ end
 
 def config_for(os)
   case os
-  when 'debian-10-x86_64', 'ubuntu-20.04-x86_64'
+  when 'debian-10-x86_64', 'debian-11-x86_64', 'ubuntu-20.04-x86_64'
     { name: '>= 3.1.1', class: 'ge311', config: TEST_CONFIG_GE311 }
   else
     { name: '< 3.1.1', class: 'lt311', config: TEST_CONFIG_LT311 }


### PR DESCRIPTION
Debian-11 is using geoipupdate 4.6, default value for config version was missing in module data.