### PR TITLE
Incur systemd units on Debian-11

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,10 +1,10 @@
 ---
 fixtures:
   forge_modules:
-    'stdlib':
+    stdlib:
       repo: 'puppetlabs/stdlib'
-    'systemd':
-      repo: 'camptocamp/systemd'
+    systemd:
+      repo: 'puppet/systemd'
   repositories:
     facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
     puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Puppet Forge: ![PDK Version](https://img.shields.io/puppetforge/pdk-version/trep
   - [Update scheduling](#update-scheduling)
 - [Reference](#reference)
 - [Limitations](#limitations)
+  - [Debian 11 - Bullseye](#debian-11-bullseye)
 - [Development](#development)
 - [Copyright](#copyright)
 
@@ -134,7 +135,6 @@ Updates, if handled by SystemD, can be scheduled by setting `geoip::update_timer
 
 The parameter `geoip::update_scatter` defines the seconds for systemd timer AccuracySec option (see [systemd.timer(5)#AccuracySec](https://www.freedesktop.org/software/systemd/man/systemd.timer.html#AccuracySec=)) to prevent multiple nodes to update at the same time.
 
-
 ## Reference
 
 Automatically generated reference documentation is available in the [REFERENCE.md][2] file or at [https://rtib.github.io/puppet-geoip/][3].
@@ -144,6 +144,10 @@ Automatically generated reference documentation is available in the [REFERENCE.m
 For supported operating systems and dependencies, see [metadata.json](https://github.com/rtib/puppet-cassandra/blob/main/metadata.json).
 
 Extensive itegration tests are run nightly to assure quality  and compatibility with next releases.
+
+### Debian 11 - Bullseye
+
+The `geoipupdate` package available in Debian Bullseye release is shipping SystemD units for service and timer to conduct weekly updates of the database. Default behaviour of the module will shift to use `systemd_config: dropin` on Debian-11 by default to rebuild the functionality on the changed environment.
 
 ## Development
 

--- a/data/Debian-11.yaml
+++ b/data/Debian-11.yaml
@@ -1,2 +1,4 @@
 ---
 geoip::config_version: ge311
+geoip::service_name: geoipupdate
+geoip::systemd_config: dropin

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,7 @@
 # @param config_version the config version to use for geoipupdate
 # @param config hash of configuration options
 # @param manage_service whether to manage database updating service
+# @param systemd_config type of configuration how changes are applied to systemd
 # @param service_user effective user the update service should run
 # @param service_group effective group the update service should run
 # @param update_path path to the geoipupdate tool, used by update service
@@ -44,6 +45,7 @@ class geoip (
   Enum['lt311','ge311']     $config_version = 'lt311',
   Hash                      $config = {},
   Boolean                   $manage_service = true,
+  Enum['unit', 'dropin']    $systemd_config = 'unit',
   String                    $service_user = 'root',
   String                    $service_group = 'root',
   Stdlib::Absolutepath      $update_path = '/usr/bin/geoipupdate',

--- a/manifests/systemd/service.pp
+++ b/manifests/systemd/service.pp
@@ -6,8 +6,8 @@
 # @param restart update service retry behaviour
 # @param restart_sec time to wait before retry
 class geoip::systemd::service (
-  String                 $restart = 'on-failure',
-  String                 $restart_sec = '5min',
+  String $restart = 'on-failure',
+  String $restart_sec = '5min',
 ) {
   if $geoip::systemd_config == 'unit' {
     systemd::unit_file{ "${geoip::service_name}.service":

--- a/manifests/systemd/timer.pp
+++ b/manifests/systemd/timer.pp
@@ -3,6 +3,8 @@
 # This class will create a SystemD timer unit triggering the update service on
 # each wallclock timer.
 #
+# @param overwrite_wallclocks if systemd_config is set to dropin, the existing timer may already have wallclocks, this aboud to overwrite or append them
+#
 class geoip::systemd::timer(
   Boolean $overwrite_wallclocks = true,
 ) {

--- a/manifests/systemd/timer.pp
+++ b/manifests/systemd/timer.pp
@@ -3,20 +3,41 @@
 # This class will create a SystemD timer unit triggering the update service on
 # each wallclock timer.
 #
-class geoip::systemd::timer {
-  if $geoip::update_timers.length > 0 {
-    systemd::unit_file{ "${geoip::service_name}.timer":
-      ensure  => $geoip::ensure,
-      content => epp('geoip/timer_unit.epp'),
+class geoip::systemd::timer(
+  Boolean $overwrite_wallclocks = true,
+) {
+  if $geoip::systemd_config == 'unit' {
+    if $geoip::update_timers.length > 0 {
+      systemd::unit_file{ "${geoip::service_name}.timer":
+        ensure  => $geoip::ensure,
+        content => epp('geoip/timer_unit.epp'),
+      }
+      ~> service { "${geoip::service_name}.timer":
+        ensure => 'running',
+        enable => true,
+      }
+    } else {
+      service { "${geoip::service_name}.timer":
+        ensure => 'stopped',
+        enable => false,
+      }
     }
-    ~> service { "${geoip::service_name}.timer":
-      ensure => 'running',
-      enable => true,
+  } elsif $geoip::systemd_config == 'dropin' {
+    systemd::dropin_file { '10-head.conf':
+      unit    => "${geoip::service_name}.timer",
+      content => epp('geoip/timer_dropin_10.epp'),
     }
-  } else {
-    service { "${geoip::service_name}.timer":
-      ensure => 'stopped',
-      enable => false,
+    if $overwrite_wallclocks {
+      systemd::dropin_file { '20-clearclocks.conf':
+        unit    => "${geoip::service_name}.timer",
+        content => epp('geoip/timer_dropin_20.epp'),
+      }
+    }
+    if $geoip::update_timers.length > 0 {
+      systemd::dropin_file { '30-wallclocks.conf':
+        unit    => "${geoip::service_name}.timer",
+        content => epp('geoip/timer_dropin_30.epp'),
+      }
     }
   }
 }

--- a/spec/classes/systemd/service_spec.rb
+++ b/spec/classes/systemd/service_spec.rb
@@ -10,7 +10,10 @@ describe 'geoip' do
 
         context 'default config' do
           let(:params) do
-            default_config(os)
+            default_config(os).merge({
+                                       systemd_config: 'unit',
+              service_name: 'geoip_update'
+                                     })
           end
 
           it { is_expected.to compile }
@@ -74,10 +77,12 @@ describe 'geoip' do
 
         context 'alternate user/group config' do
           let(:params) do
-            default_config(os).merge(
-              'service_user'  => 'geo_user',
-              'service_group' => 'geo_group',
-            )
+            default_config(os).merge({
+                                       service_user: 'geo_user',
+              service_group: 'geo_group',
+              systemd_config: 'unit',
+              service_name: 'geoip_update'
+                                     })
           end
 
           it { is_expected.to compile }

--- a/spec/classes/systemd/timer_spec.rb
+++ b/spec/classes/systemd/timer_spec.rb
@@ -14,9 +14,11 @@ describe 'geoip' do
         it { is_expected.to compile }
         describe 'add one timer' do
           let(:params) do
-            default_config(os).merge(
-              'update_timers' => ['Mon..Fri *-*-* 06:30:00'],
-            )
+            default_config(os).merge({
+                                       update_timers: ['Mon..Fri *-*-* 06:30:00'],
+                systemd_config: 'unit',
+                service_name: 'geoip_update'
+                                     })
           end
 
           context 'systemd timer file contents' do
@@ -37,10 +39,12 @@ describe 'geoip' do
 
         describe 'add multiple timers' do
           let(:params) do
-            default_config(os).merge(
-              'update_timers' => ['Mon..Fri *-*-* 06:30:00', 'Mon..Fri *-*-* 18:30:00'],
-              'update_scatter' => 300,
-            )
+            default_config(os).merge({
+                                       update_timers: ['Mon..Fri *-*-* 06:30:00', 'Mon..Fri *-*-* 18:30:00'],
+              update_scatter: 300,
+              systemd_config: 'unit',
+              service_name: 'geoip_update'
+                                     })
           end
 
           context 'systemd timer file contents' do

--- a/templates/service_dropin_10.epp
+++ b/templates/service_dropin_10.epp
@@ -1,0 +1,6 @@
+# Managed by puppet module geoip.
+# Do not edit!
+
+[Service]
+ExecStart=
+ExecStart=<%= $geoip::update_path %> -v -f <%= $geoip::config_path %>

--- a/templates/service_dropin_20.epp
+++ b/templates/service_dropin_20.epp
@@ -1,0 +1,8 @@
+# Managed by puppet module geoip.
+# Do not edit!
+
+[Service]
+User=<%= $geoip::service_user %>
+Group=<%= $geoip::service_group %>
+StandardOutput=journal
+StandardError=journal

--- a/templates/service_dropin_30.epp
+++ b/templates/service_dropin_30.epp
@@ -1,0 +1,7 @@
+# Managed by puppet module geoip.
+# Do not edit!
+
+[Service]
+Type=exec
+Restart=<%= $geoip::systemd::service::restart %>
+RestartSec=<%= $geoip::systemd::service::restart_sec %>

--- a/templates/timer_dropin_10.epp
+++ b/templates/timer_dropin_10.epp
@@ -1,0 +1,6 @@
+# Managed by puppet module geoip.
+# Do not edit!
+
+[Timer]
+Persistent=true
+AccuracySec=<%= $geoip::update_scatter %>

--- a/templates/timer_dropin_20.epp
+++ b/templates/timer_dropin_20.epp
@@ -1,0 +1,5 @@
+# Managed by puppet module geoip.
+# Do not edit!
+
+[Timer]
+OnCalendar=

--- a/templates/timer_dropin_30.epp
+++ b/templates/timer_dropin_30.epp
@@ -1,0 +1,7 @@
+# Managed by puppet module geoip.
+# Do not edit!
+
+[Timer]
+<% $geoip::update_timers.each |String $value| { -%>
+OnCalendar=<%= $value %>
+<% } -%>


### PR DESCRIPTION
Debian-11 got a systemd units `geoipupdate` to run the service and trigger in by a timer. This change:

* enables to configure service and timer units by dropins
* switches default for Debian-11 to dropin type
* rebuild the same behaviour of a Puppet manifest on Debian-11
* closes #41 